### PR TITLE
Restore social proof image + laurels, theme rating star, fix feature showcase wrapping

### DIFF
--- a/Sources/Onboarding/Models/ColorPalette.swift
+++ b/Sources/Onboarding/Models/ColorPalette.swift
@@ -19,6 +19,11 @@ public protocol ColorPalette {
     var progressBarBackgroundColor: AnyShapeStyle { get }
     var orbitColor: Color { get }
     var accentColor: Color { get }
+    var ratingStarColor: Color { get }
+}
+
+public extension ColorPalette {
+    var ratingStarColor: Color { Color(red: 0.82, green: 0.65, blue: 0.2) }
 }
 
 extension ColorPalette where Self == TestColorPalette {
@@ -40,6 +45,7 @@ struct TestColorPalette: ColorPalette {
     var progressBarBackgroundColor: AnyShapeStyle = AnyShapeStyle(Color(uiColor: .systemGray6))
     var orbitColor: Color = Color(uiColor: .systemGray6)
     var accentColor: Color = Color(uiColor: .systemYellow)
+    var ratingStarColor: Color = Color(red: 0.82, green: 0.65, blue: 0.2)
 }
 
 #Preview {

--- a/Sources/Onboarding/Models/SocialProofStep.swift
+++ b/Sources/Onboarding/Models/SocialProofStep.swift
@@ -8,32 +8,23 @@
 import Foundation
 
 struct SocialProofStep: Sendable, Hashable {
-    let image: ImageMeta?
+    let image: ImageMeta
     let welcomeHeadline: String
     let welcomeSubheadline: String
     let userReview: String
-    let stats: [StatItem]
     let message: String
-    let messageAuthor: String
     let answer: StepAnswer
-
-    struct StatItem: Sendable, Hashable {
-        let value: String
-        let label: String
-    }
 }
 
 extension SocialProofStep {
 
     init(response: OnboardingStepResponse.SocialProofStep, localizer: Localizer) {
         self.init(
-            image: ImageMeta(response: response.image),
+            image: ImageMeta(response: response.image) ?? ImageMeta(imageType: .named(""), aspectRatioType: "fit"),
             welcomeHeadline: response.welcomeHeadline.localized(using: localizer),
             welcomeSubheadline: response.welcomeSubheadline.localized(using: localizer),
             userReview: response.userReview.localized(using: localizer),
-            stats: response.stats.map { StatItem(value: $0.value.localized(using: localizer), label: $0.label.localized(using: localizer)) },
             message: response.message.localized(using: localizer),
-            messageAuthor: response.messageAuthor.localized(using: localizer),
             answer: StepAnswer(response: response.answer, localizer: localizer)
         )
     }

--- a/Sources/Onboarding/Network/OnboardingStepResponse.swift
+++ b/Sources/Onboarding/Network/OnboardingStepResponse.swift
@@ -226,9 +226,9 @@ struct OnboardingStepResponse: Decodable {
         let welcomeHeadline: String
         let welcomeSubheadline: String
         let userReview: String
-        let stats: [StatItem]
+        let stats: [StatItem]?
         let message: String
-        let messageAuthor: String
+        let messageAuthor: String?
         let answer: StepAnswer
     }
 

--- a/Sources/Onboarding/View/FeatureShowcaseStepView.swift
+++ b/Sources/Onboarding/View/FeatureShowcaseStepView.swift
@@ -26,14 +26,14 @@ struct FeatureShowcaseStepView: View {
     // MARK: - Top Section
 
     private var topSection: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 24) {
             imageView
-                .frame(maxHeight: .infinity)
                 .opacity(showImage ? 1 : 0)
                 .scaleEffect(showImage ? 1 : 0.85)
             textContent
                 .offset(y: showBottomSection ? 0 : 40)
                 .opacity(showBottomSection ? 1 : 0)
+            Spacer(minLength: 0)
         }
         .layoutPriority(65)
     }

--- a/Sources/Onboarding/View/FeatureShowcaseStepView.swift
+++ b/Sources/Onboarding/View/FeatureShowcaseStepView.swift
@@ -91,6 +91,7 @@ struct FeatureShowcaseStepView: View {
             .fontWeight(.bold)
             .foregroundStyle(viewModel.colorPalette.textColor)
             .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: - Description

--- a/Sources/Onboarding/View/FeatureShowcaseStepView.swift
+++ b/Sources/Onboarding/View/FeatureShowcaseStepView.swift
@@ -26,26 +26,26 @@ struct FeatureShowcaseStepView: View {
     // MARK: - Top Section
 
     private var topSection: some View {
-        imageView
-            .frame(maxHeight: .infinity)
-            .layoutPriority(65)
-            .opacity(showImage ? 1 : 0)
-            .scaleEffect(showImage ? 1 : 0.85)
+        VStack(spacing: 0) {
+            imageView
+                .frame(maxHeight: .infinity)
+                .opacity(showImage ? 1 : 0)
+                .scaleEffect(showImage ? 1 : 0.85)
+            textContent
+                .offset(y: showBottomSection ? 0 : 40)
+                .opacity(showBottomSection ? 1 : 0)
+        }
+        .layoutPriority(65)
     }
 
     // MARK: - Bottom Section
 
     private var bottomSection: some View {
-        VStack {
-            textContent
-                .offset(y: showBottomSection ? 0 : 40)
-                .opacity(showBottomSection ? 1 : 0)
-            buttonContent
-        }
-        .background {
-            step.backgroundColor
-                .ignoresSafeArea()
-        }
+        buttonContent
+            .background {
+                step.backgroundColor
+                    .ignoresSafeArea()
+            }
     }
 
     // MARK: - Text Content

--- a/Sources/Onboarding/View/SocialProofView.swift
+++ b/Sources/Onboarding/View/SocialProofView.swift
@@ -55,7 +55,7 @@ struct SocialProofView: View {
     private var headerSection: some View {
         VStack(spacing: 4) {
             Text(step.welcomeHeadline)
-                .font(.subheadline)
+                .font(.headline)
                 .fontWeight(.semibold)
                 .textCase(.uppercase)
                 .tracking(1.2)
@@ -67,7 +67,7 @@ struct SocialProofView: View {
                 .foregroundStyle(viewModel.colorPalette.accentColor)
 
             Text(step.welcomeSubheadline)
-                .font(.title)
+                .font(.largeTitle)
                 .fontWeight(.bold)
                 .apply { view in
                     if #available(iOS 16.1, *) {

--- a/Sources/Onboarding/View/SocialProofView.swift
+++ b/Sources/Onboarding/View/SocialProofView.swift
@@ -53,7 +53,7 @@ struct SocialProofView: View {
     // MARK: - Header Section
 
     private var headerSection: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 4) {
             Text(step.welcomeHeadline)
                 .font(.subheadline)
                 .fontWeight(.semibold)

--- a/Sources/Onboarding/View/SocialProofView.swift
+++ b/Sources/Onboarding/View/SocialProofView.swift
@@ -6,7 +6,6 @@ struct SocialProofView: View {
 
     @State private var showContent = false
     @State private var showStars = false
-    @State private var showStats = false
     @State private var showMessage = false
     @State private var showButton = false
 
@@ -14,7 +13,7 @@ struct SocialProofView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Spacer()
+            imageView
             VStack(spacing: 32) {
                 headerSection
                     .opacity(showContent ? 1 : 0)
@@ -23,10 +22,6 @@ struct SocialProofView: View {
                 ratingSection
                     .opacity(showStars ? 1 : 0)
                     .scaleEffect(showStars ? 1 : 0.9)
-
-                statsSection
-                    .opacity(showStats ? 1 : 0)
-                    .offset(y: showStats ? 0 : 20)
 
                 messageSection
                     .opacity(showMessage ? 1 : 0)
@@ -44,6 +39,15 @@ struct SocialProofView: View {
         .task {
             await animateIn()
         }
+    }
+
+    // MARK: - Image
+
+    private var imageView: some View {
+        OnboardingImage(image: step.image, bundle: viewModel.configuration.bundle)
+            .foregroundStyle(viewModel.colorPalette.secondaryTextColor)
+            .aspectRatio(1.0, contentMode: .fit)
+            .frame(maxWidth: .infinity)
     }
 
     // MARK: - Header Section
@@ -78,124 +82,65 @@ struct SocialProofView: View {
     // MARK: - Rating Section
 
     private var ratingSection: some View {
-        VStack(spacing: 12) {
-            HStack(spacing: 6) {
-                ForEach(0..<5, id: \.self) { index in
-                    Image(systemName: "star.fill")
-                        .font(.title3)
-                        .foregroundStyle(Color.yellow.opacity(0.85))
-                        .scaleEffect(showStars ? 1 : 0)
-                        .animation(
-                            .spring(response: 0.4, dampingFraction: 0.6)
-                                .delay(Double(index) * 0.08),
-                            value: showStars
-                        )
-                }
+        HStack(spacing: 12) {
+            laurelView
+            VStack(spacing: 8) {
+                starsView
+                Text(step.userReview)
+                    .font(.footnote)
+                    .fontWeight(.medium)
+                    .foregroundStyle(viewModel.colorPalette.secondaryTextColor)
+                    .apply { view in
+                        if #available(iOS 16.1, *) {
+                            view.fontDesign(.rounded)
+                        }
+                    }
             }
-
-            Text(step.userReview)
-                .font(.footnote)
-                .fontWeight(.medium)
-                .foregroundStyle(viewModel.colorPalette.secondaryTextColor)
-                .apply { view in
-                    if #available(iOS 16.1, *) {
-                        view.fontDesign(.rounded)
-                    }
-                }
-        }
-        .padding(.vertical, 20)
-        .padding(.horizontal, 28)
-        .background {
-            RoundedRectangle(cornerRadius: 16)
-                .fill(viewModel.colorPalette.secondaryButtonBackground.opacity(0.4))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 16)
-                        .strokeBorder(viewModel.colorPalette.accentColor.opacity(0.2), lineWidth: 1)
-                }
+            laurelView
+                .scaleEffect(x: -1, y: 1)
         }
     }
 
-    // MARK: - Stats Section
-
-    @ViewBuilder
-    private var statsSection: some View {
-        if !step.stats.isEmpty {
-            HStack(spacing: 0) {
-                ForEach(Array(step.stats.enumerated()), id: \.offset) { index, stat in
-                    if index > 0 {
-                        statDivider
-                    }
-                    statItem(value: stat.value, label: stat.label)
-                }
+    private var starsView: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<5, id: \.self) { index in
+                Image(systemName: "star.fill")
+                    .font(.title3)
+                    .foregroundStyle(Color.yellow.opacity(0.85))
+                    .scaleEffect(showStars ? 1 : 0)
+                    .animation(
+                        .spring(response: 0.4, dampingFraction: 0.6)
+                            .delay(Double(index) * 0.08),
+                        value: showStars
+                    )
             }
-            .padding(.vertical, 20)
-            .padding(.horizontal, 12)
         }
     }
 
-    private func statItem(value: String, label: String) -> some View {
-        VStack(spacing: 2) {
-            Text(value)
-                .font(.title3)
-                .fontWeight(.bold)
-                .apply { view in
-                    if #available(iOS 16.1, *) {
-                        view.fontDesign(.rounded)
-                    }
-                }
-                .foregroundStyle(viewModel.colorPalette.textColor)
-
-            Text(label)
-                .font(.caption2)
-                .fontWeight(.medium)
-                .textCase(.uppercase)
-                .tracking(0.5)
-                .foregroundStyle(viewModel.colorPalette.secondaryTextColor)
-                .apply { view in
-                    if #available(iOS 16.1, *) {
-                        view.fontDesign(.rounded)
-                    }
-                }
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var statDivider: some View {
-        Circle()
-            .fill(viewModel.colorPalette.secondaryTextColor.opacity(0.4))
-            .frame(width: 4, height: 4)
+    private var laurelView: some View {
+        Image("laurel", bundle: .module)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(height: 52)
+            .foregroundStyle(viewModel.colorPalette.secondaryTextColor)
     }
 
     // MARK: - Message Section
 
     private var messageSection: some View {
-        VStack(spacing: 16) {
-            Text("\(step.message)")
-                .font(.callout)
-                .fontWeight(.regular)
-                .italic()
-                .apply { view in
-                    if #available(iOS 16.1, *) {
-                        view.fontDesign(.serif)
-                    }
+        Text(step.message)
+            .font(.callout)
+            .fontWeight(.regular)
+            .italic()
+            .apply { view in
+                if #available(iOS 16.1, *) {
+                    view.fontDesign(.serif)
                 }
-                .foregroundStyle(viewModel.colorPalette.textColor.opacity(0.9))
-                .multilineTextAlignment(.center)
-                .lineSpacing(6)
-
-            Text(step.messageAuthor)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .textCase(.uppercase)
-                .tracking(1)
-                .apply { view in
-                    if #available(iOS 16.1, *) {
-                        view.fontDesign(.rounded)
-                    }
-                }
-                .foregroundStyle(viewModel.colorPalette.secondaryTextColor)
-        }
-        .padding(.horizontal, 8)
+            }
+            .foregroundStyle(viewModel.colorPalette.textColor.opacity(0.9))
+            .multilineTextAlignment(.center)
+            .lineSpacing(6)
+            .padding(.horizontal, 8)
     }
 
     // MARK: - Button
@@ -223,11 +168,6 @@ struct SocialProofView: View {
         }
 
         try? await Task.sleep(for: .milliseconds(400))
-        withAnimation(.easeOut(duration: 0.4)) {
-            showStats = true
-        }
-
-        try? await Task.sleep(for: .milliseconds(200))
         withAnimation(.easeOut(duration: 0.4)) {
             showMessage = true
         }

--- a/Sources/Onboarding/View/SocialProofView.swift
+++ b/Sources/Onboarding/View/SocialProofView.swift
@@ -106,7 +106,7 @@ struct SocialProofView: View {
             ForEach(0..<5, id: \.self) { index in
                 Image(systemName: "star.fill")
                     .font(.title3)
-                    .foregroundStyle(Color.yellow.opacity(0.85))
+                    .foregroundStyle(viewModel.colorPalette.ratingStarColor)
                     .scaleEffect(showStars ? 1 : 0)
                     .animation(
                         .spring(response: 0.4, dampingFraction: 0.6)


### PR DESCRIPTION
## Summary
- Restore hero image + laurel-decorated rating in `SocialProofView`; drop `stats` and `messageAuthor`
- Expose `ratingStarColor` on `ColorPalette` (default muted gold via protocol extension — non-breaking)
- Tighten welcome header spacing and bump font sizes (`subheadline` → `headline`, `title` → `largeTitle`)
- Fix feature showcase title truncation (`fixedSize` vertical) and group title with the image

## Test plan
- [x] `xcodebuild -scheme Onboarding -destination 'generic/platform=iOS' build` passes
- [ ] Preview `MockOnboardingView` for `SocialProofView` — image at top, laurels around stars, italic quote, tighter headline spacing, larger welcome fonts, muted-gold stars
- [ ] Preview `FeatureShowcaseStepView` with a long title — wraps multi-line, sits grouped with the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)