### PR TITLE
Add identify and reset to AnalyticsProtocol

### DIFF
--- a/Sources/CoreAnalytics/Implementations/AnalyticsProtocol.swift
+++ b/Sources/CoreAnalytics/Implementations/AnalyticsProtocol.swift
@@ -10,6 +10,17 @@ import Foundation
 public protocol AnalyticsProtocol {
 
     func track(event: Event)
-    
+
     func setupUserProperties(_ params: Parameters)
+
+    func identify(distinctId: String, userProperties: Parameters)
+
+    func reset()
+}
+
+public extension AnalyticsProtocol {
+
+    func identify(distinctId: String, userProperties: Parameters) {}
+
+    func reset() {}
 }

--- a/Sources/CoreAnalytics/Implementations/CompositeAnalytics.swift
+++ b/Sources/CoreAnalytics/Implementations/CompositeAnalytics.swift
@@ -18,8 +18,16 @@ struct CompositeAnalytics: AnalyticsProtocol {
     func track(event: Event) {
         analytics.forEach { $0.track(event: event) }
     }
-    
+
     func setupUserProperties(_ params: Parameters) {
         analytics.forEach { $0.setupUserProperties(params) }
+    }
+
+    func identify(distinctId: String, userProperties: Parameters) {
+        analytics.forEach { $0.identify(distinctId: distinctId, userProperties: userProperties) }
+    }
+
+    func reset() {
+        analytics.forEach { $0.reset() }
     }
 }


### PR DESCRIPTION
## Summary

Adds two new requirements to `AnalyticsProtocol`:

```swift
func identify(distinctId: String, userProperties: Parameters)
func reset()
```

Both come with default no-op implementations via a public protocol extension, so existing consumers continue to compile without changes. `CompositeAnalytics` fans both calls out to its child analytics.

## Why

Previously, host apps that wanted to identify users in PostHog/Amplitude/etc. had to either:
- Bypass the protocol and call SDK methods directly (`PostHogSDK.shared.identify(...)`), or
- Build their own dispatcher class to fan out to multiple analytics providers.

With `identify` and `reset` on the protocol, host apps can route everything through `AnalyticsDI.shared.analytics` — `CompositeAnalytics` handles fan-out, and individual provider classes (`PostHogAnalytics`, `AmplitudeAnalytics`) implement only the parts they care about, ignoring the rest via the default no-op.

## Backward compatibility

- Adding new requirements is normally a breaking change for protocol conformers, but the public `extension AnalyticsProtocol` provides default empty implementations. Existing types that conform to `AnalyticsProtocol` (e.g. `LoggerAnalytics`, third-party implementations) compile and run unchanged.
- No changes to existing methods (`track`, `setupUserProperties`).
- No type signature changes.

## Suggested release

Minor version bump → **`1.8.0`** (additive feature, source-compatible).

## Test plan

- [x] Existing `LoggerAnalytics` (in this package) compiles unchanged — verified by build.
- [x] Verified Faultier consumer compiles against this change with both new methods being routed through `analytics.identify(...)` and `analytics.reset()`.
- [ ] Tag `1.8.0` on main after merge, run `swift package describe` to confirm public API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)